### PR TITLE
Optimize TJSON.encode

### DIFF
--- a/lib/tjson/TJSON.hx
+++ b/lib/tjson/TJSON.hx
@@ -379,36 +379,39 @@ class SimpleStyle implements EncodeStyle{
 
 
 class FancyStyle implements EncodeStyle{
-	public function new(){
-
+	public var tab(default, null):String;
+	public function new(tab:String = "    "){
+		this.tab = tab;
+		charTimesNCache = [""];
 	}
 	public function beginObject(depth:Int):String{
 		return "{\n";
 	}
 	public function endObject(depth:Int):String{
-		return "\n"+charTimesN("    ",depth)+"}";
+		return "\n"+charTimesN(depth)+"}";
 	}
 	public function beginArray(depth:Int):String{
 		return "[\n";
 	}
 	public function endArray(depth:Int):String{
-		return "\n"+charTimesN("    ",depth)+"]";
+		return "\n"+charTimesN(depth)+"]";
 	}
 	public function firstEntry(depth:Int):String{
-		return charTimesN("    ",depth+1)+' ';
+		return charTimesN(depth+1)+' ';
 	}
 	public function entrySeperator(depth:Int):String{
-		return "\n"+charTimesN("    ",depth+1)+",";
+		return "\n"+charTimesN(depth+1)+",";
 	}
 	public function keyValueSeperator(depth:Int):String{
 		return " : ";
 	}
-	private function charTimesN(str:String, n:Int):String{
-		var buffer = new StringBuf();
-		for(x in 0...n){
-			buffer.add(str);
+	private var charTimesNCache:Array<String>;
+	private function charTimesN(n:Int):String{
+		return if (n < charTimesNCache.length) {
+			charTimesNCache[n];
+		} else {
+			charTimesNCache[n] = charTimesN(n-1) + tab;
 		}
-		return buffer.toString();
 	}
 	
 }


### PR DESCRIPTION
I'm encoding some large object, and found it a little bit slow, so I took the chance to improve the encode method:
- Use `StringBuf` instead of `+=`.
- Added a `tab` property to `FancyStyle`.
- Use a internal cache for `FancyStyle`'s `charTimesN` method.

I tested with a large (1.8M) json file, compiled to neko:

``` haxe

package ;
import TestParser;
class TestAll {
    function new(){

    }
    static function main(){
        var t = Sys.cpuTime();
        var obj = tjson.TJSON.parse(sys.io.File.getContent("large.json"));
        trace(Sys.cpuTime() - t);

        var t = Sys.cpuTime();
        for (i in 0...10) {
            tjson.TJSON.encode(obj);
        }
        trace(Sys.cpuTime() - t);

        var t = Sys.cpuTime();
        for (i in 0...10) {
            tjson.TJSON.encode(obj, "fancy");
        }
        trace(Sys.cpuTime() - t);
    }
}
```

original:

```
TestAll.hx:11: 11.27
TestAll.hx:17: 8.63
TestAll.hx:23: 15.23
```

improved:

```
TestAll.hx:11: 11.29
TestAll.hx:17: 4.15
TestAll.hx:23: 5.89
```
