### PR TITLE
Modified encodeAnonymousObject to also go through fields of class instance.

### DIFF
--- a/lib/tjson/TJSON.hx
+++ b/lib/tjson/TJSON.hx
@@ -324,7 +324,14 @@ class TJSON {
 	private static function encodeAnonymousObject(buffer:StringBuf, obj:Dynamic,style:EncodeStyle,depth:Int):Void {
 		buffer.add(style.beginObject(depth));
 		var fieldCount = 0;
-		for (field in Reflect.fields(obj)){
+		var fields:Array<String>;
+		var cls = Type.getClass(obj);
+		if (cls != null) {
+			fields = Type.getInstanceFields(cls);
+		} else {
+			fields = Reflect.fields(obj);
+		}
+		for (field in fields){
 			if(fieldCount++ > 0) buffer.add(style.entrySeperator(depth));
 			else buffer.add(style.firstEntry(depth));
 			var value:Dynamic = Reflect.field(obj,field);


### PR DESCRIPTION
Maybe it would be a good idea to rename the function to just encodeObject? I didn't do it as I didn't want to do too big a change.
Also it should be possible to parse JSON directly to class instance (not anonymous object), just need to also store class name and have it available when parsing. Similar to how Haxe serialization works.
