### PR TITLE
Removed cache from the special Date object.

### DIFF
--- a/lib/tjson/TJSON.hx
+++ b/lib/tjson/TJSON.hx
@@ -513,6 +513,10 @@ class TJSONEncoder{
 		else if(Std.is(value,Bool)){
 			return(value);
 		}
+		else if (Std.is(value, Date)) {
+			// Date should not be cached, it has a special encoding (see encodeObject).
+			return encodeObject(value,style,depth+1);
+		}
 		else if(Reflect.isObject(value)){
 			var ret = cacheEncode(value);
 			if(ret != null) return ret;


### PR DESCRIPTION
I think the encoded Date object is small enough not to be cached, so it can be self-contained. It happened to me when using TJSON-encoded data in a REST service that the Date was cached but the cached object didn't exist in the response. What do you think?
