### PR TITLE
Update TJSON.hx

### DIFF
--- a/lib/tjson/TJSON.hx
+++ b/lib/tjson/TJSON.hx
@@ -436,7 +436,7 @@ class TJSONEncoder{
 			if(vStr!=null){
 				if(fieldCount++ > 0) buffer.add(style.entrySeperator(depth));
 				else buffer.add(style.firstEntry(depth));
-				buffer.add('"'+field+'"'+style.keyValueSeperator(depth)+vStr);
+				buffer.add('"'+field+'"'+style.keyValueSeperator(depth)+Std.string(vStr));
 			}
 			
 		}


### PR DESCRIPTION
Not sure why this fails, but this change fixed my `TypeError`

I ran into the error using Haxelow (which uses TJSON) with the Python target

```
    buffer_b.write(Std.string((((("\"" + ("null" if field is None else field)) + "\"") + Std.string(style.keyValueSeperator(depth))) + ("null" if vStr is None else vStr))))
TypeError: Can't convert 'int' object to str implicitly
```

Example code here: https://github.com/MatthijsKamstra/haxepython/blob/master/04haxelow/code/src/Main.hx